### PR TITLE
DRYing unit tests

### DIFF
--- a/test/hardware/instructions/Call.spec.js
+++ b/test/hardware/instructions/Call.spec.js
@@ -10,34 +10,34 @@ describe('testIntructionsCall', function() {
         reg.CLEAR_STACK();
         reg.CARRY = 0; reg.PARITY = 0; reg.SIGN = 1; reg.ZERO = 1;
         expect(reg.PC).toEqual(0);
-        operation[op](reg, 0, 8);  // mem location 0x0008
-        expect(reg.PC).toEqual(8); // called to 8
+        operation[op](reg, 0, 8);
+        expect(reg.PC).toEqual(8);
         reg.POP();
-        expect(reg.PC).toEqual(0); // called to 0
+        expect(reg.PC).toEqual(0);
         
         reg.CLEAR_STACK();
         reg.CARRY = 1; reg.PARITY = 1; reg.SIGN = 0; reg.ZERO = 0;
         reg.PC = 250;
-        operation[op](reg, 5, 100);  // mem location 0x0564
-        expect(reg.PC).toEqual(0x0564);// called to 0x0564
+        operation[op](reg, 5, 100);
+        expect(reg.PC).toEqual(0x0564);
         reg.POP();
-        expect(reg.PC).toEqual(250); // called to 250
+        expect(reg.PC).toEqual(250);
         
         reg.CLEAR_STACK();
         reg.CARRY = 0; reg.PARITY = 1; reg.SIGN = 0; reg.ZERO = 1;
         reg.PC = 133;
-        operation[op](reg, 0, 95);  // mem location 0x005F
-        expect(reg.PC).toEqual(95); // called to 95
+        operation[op](reg, 0, 95);
+        expect(reg.PC).toEqual(95);
         reg.POP();
-        expect(reg.PC).toEqual(133); // called to 133
+        expect(reg.PC).toEqual(133);
         
         reg.CLEAR_STACK();
         reg.CARRY = 1; reg.PARITY = 0; reg.SIGN = 1; reg.ZERO = 0;
         reg.PC = 2000;
-        operation[op](reg, 0, 55);  // mem location 0x0037
-        expect(reg.PC).toEqual(55); // called to 100
+        operation[op](reg, 0, 55);
+        expect(reg.PC).toEqual(55);
         reg.POP();
-        expect(reg.PC).toEqual(2000); // called to 2000
+        expect(reg.PC).toEqual(2000);
     });
     
     // test call if not zero

--- a/test/hardware/instructions/Load.spec.js
+++ b/test/hardware/instructions/Load.spec.js
@@ -1,6 +1,5 @@
 /**
- * Tests the Load operations. Currently only tests 49 of 71
- * TODO test M and I MOV commands
+ * Tests the Load operations.
  */
 describe("testIntructionsLoad", function() {
     /* Incremented every command ran */
@@ -93,9 +92,9 @@ describe("testIntructionsLoad", function() {
             var op = operation["MOV_" + R[i] + "_I"];
 
             reg[R[i]] = 30;
-            expect(reg[R[i]]).toEqual(30); // before R holds 30
+            expect(reg[R[i]]).toEqual(30);
             operation[op](reg, 22);
-            expect(reg[R[i]]).toEqual(22); //  after R holds 22
+            expect(reg[R[i]]).toEqual(22);
 
         }
 
@@ -106,9 +105,9 @@ describe("testIntructionsLoad", function() {
 
         reg.H = 0;
         reg.L = 3;
-        expect(reg.M).toEqual(7); // before M gets 7 from memory
+        expect(reg.M).toEqual(7);
         operation[operation.MOV_M_I](reg, 22);
-        expect(reg.M).toEqual(22); // before M gets 22 from memory
+        expect(reg.M).toEqual(22);
 
     });
 });

--- a/test/hardware/instructions/Math.Addition.spec.js
+++ b/test/hardware/instructions/Math.Addition.spec.js
@@ -18,22 +18,12 @@ describe("testIntructionsAddition", function () {
             expect(reg.A).toEqual(0);
             expect(reg[r]).toEqual(0);
 
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(1);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
-
             // When A = 53, R = 42
             reg.A  = 53;
             reg[r] = 42;
             operation[operation["ADD_" + r]](reg);
             expect(reg.A).toEqual(95);
             expect(reg[r]).toEqual(42);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(0);
 
             // When A = 128, R = 200
             reg.A  = 128;
@@ -42,20 +32,10 @@ describe("testIntructionsAddition", function () {
             expect(reg.A).toEqual(72);
             expect(reg[r]).toEqual(200);
 
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(1);
-            expect(reg.PARITY).toEqual(1);
-
             // Tests double operation no fail
             operation[operation["ADD_" + r]](reg);
             expect(reg.A).toEqual(16);
             expect(reg[r]).toEqual(200);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(1);
-            expect(reg.PARITY).toEqual(1);
         }
     });
 
@@ -68,59 +48,29 @@ describe("testIntructionsAddition", function () {
         operation[operation.ADD_A](reg);
         expect(reg.A).toEqual(0);
 
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
-
         // When A = 53
         reg.A = 53;
         operation[operation.ADD_A](reg);
         expect(reg.A).toEqual(106);
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
 
         // When A = 127
         reg.A = 127;
         operation[operation.ADD_A](reg);
         expect(reg.A).toEqual(254);
 
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
-
         // When A = 128, tests carry
         reg.A = 128;
         operation[operation.ADD_A](reg);
         expect(reg.A).toEqual(0);
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(1);
-        expect(reg.PARITY).toEqual(1);
 
         // When A = 250, tests carry
         reg.A = 250;
         operation[operation.ADD_A](reg);
         expect(reg.A).toEqual(244);
 
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(1);
-        expect(reg.PARITY).toEqual(1);
-
         // Tests double operation no fail
         operation[operation.ADD_A](reg);
         expect(reg.A).toEqual(232);
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(1);
-        expect(reg.PARITY).toEqual(1);
     });
 
     it("ADD M", function () {
@@ -131,11 +81,6 @@ describe("testIntructionsAddition", function () {
         expect(reg.A).toEqual(0);
         operation[operation["ADD_M"]](reg, 0, 0);
         expect(reg.A).toEqual(255);
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(0);
     });
 
 });

--- a/test/hardware/instructions/Math.Addition.spec.js
+++ b/test/hardware/instructions/Math.Addition.spec.js
@@ -14,48 +14,48 @@ describe("testIntructionsAddition", function () {
             reg = MolassesRegisters();
 
             // When A = 0 and R = 0
-            operation[operation["ADD_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(0);      // 0 + 0 = 0
-            expect(reg[r]).toEqual(0);      // shouldn't be affected
+            operation[operation["ADD_" + r]](reg);
+            expect(reg.A).toEqual(0);
+            expect(reg[r]).toEqual(0);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(1);   // zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // 0 is even
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(1);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
 
             // When A = 53, R = 42
             reg.A  = 53;
             reg[r] = 42;
-            operation[operation["ADD_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(95);     // 53 + 42 = 95
-            expect(reg[r]).toEqual(42);     // shouldn't be affected
+            operation[operation["ADD_" + r]](reg);
+            expect(reg.A).toEqual(95);
+            expect(reg[r]).toEqual(42);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(0); // 95 is odd
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(0);
 
             // When A = 128, R = 200
             reg.A  = 128;
             reg[r] = 200;
-            operation[operation["ADD_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(72);     // 128 + 200 = 328 -> 72
-            expect(reg[r]).toEqual(200);    // shouldn't be affected
+            operation[operation["ADD_" + r]](reg);
+            expect(reg.A).toEqual(72);
+            expect(reg[r]).toEqual(200);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(1);  // carry
-            expect(reg.PARITY).toEqual(1); // 72 is even
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(1);
+            expect(reg.PARITY).toEqual(1);
 
             // Tests double operation no fail
-            operation[operation["ADD_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(16);     // 72 + 200 = 272 -> 16
-            expect(reg[r]).toEqual(200);    // shouldn't be affected
+            operation[operation["ADD_" + r]](reg);
+            expect(reg.A).toEqual(16);
+            expect(reg[r]).toEqual(200);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(1);  // carry
-            expect(reg.PARITY).toEqual(1); // 16 is even
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(1);
+            expect(reg.PARITY).toEqual(1);
         }
     });
 
@@ -65,62 +65,62 @@ describe("testIntructionsAddition", function () {
         reg = new MolassesRegisters();
 
         // When A = 0
-        operation[operation.ADD_A](reg);  // preform op
-        expect(reg.A).toEqual(0);      // 0 + 0 = 0
+        operation[operation.ADD_A](reg);
+        expect(reg.A).toEqual(0);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
 
         // When A = 53
         reg.A = 53;
-        operation[operation.ADD_A](reg);  // preform op
-        expect(reg.A).toEqual(106);    // 53 + 53 = 106
+        operation[operation.ADD_A](reg);
+        expect(reg.A).toEqual(106);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 254 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
 
         // When A = 127
         reg.A = 127;
-        operation[operation.ADD_A](reg);  // preform op
-        expect(reg.A).toEqual(254);    // 127 + 127 = 254
+        operation[operation.ADD_A](reg);
+        expect(reg.A).toEqual(254);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 254 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
 
         // When A = 128, tests carry
         reg.A = 128;
-        operation[operation.ADD_A](reg);  // preform op
-        expect(reg.A).toEqual(0);      // 128 + 128 = 256 -> 0
+        operation[operation.ADD_A](reg);
+        expect(reg.A).toEqual(0);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(1);  // carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(1);
+        expect(reg.PARITY).toEqual(1);
 
         // When A = 250, tests carry
         reg.A = 250;
-        operation[operation.ADD_A](reg);  // preform op
-        expect(reg.A).toEqual(244);    // 250 + 250 = 500 -> 244
+        operation[operation.ADD_A](reg);
+        expect(reg.A).toEqual(244);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(1);  // carry
-        expect(reg.PARITY).toEqual(1); // 244 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(1);
+        expect(reg.PARITY).toEqual(1);
 
         // Tests double operation no fail
-        operation[operation.ADD_A](reg);  // preform op
-        expect(reg.A).toEqual(232);    // 244 + 244 = 488 -> 232
+        operation[operation.ADD_A](reg);
+        expect(reg.A).toEqual(232);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // no zero
-        expect(reg.CARRY).toEqual(1);  // carry
-        expect(reg.PARITY).toEqual(1); // 232 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(1);
+        expect(reg.PARITY).toEqual(1);
     });
 
     it("ADD M", function () {
@@ -132,10 +132,10 @@ describe("testIntructionsAddition", function () {
         operation[operation["ADD_M"]](reg, 0, 0);
         expect(reg.A).toEqual(255);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(0); // 255 is odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(0);
     });
 
 });

--- a/test/hardware/instructions/Math.AdditionCarry.spec.js
+++ b/test/hardware/instructions/Math.AdditionCarry.spec.js
@@ -18,11 +18,6 @@ describe("testIntructionsAdditionCarry", function () {
             expect(reg.A).toEqual(1);
             expect(reg[r]).toEqual(0);
 
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(0);
-
             // When A = 53, R = 42, and Carry = 1
             reg.A  = 53;
             reg[r] = 42;
@@ -30,11 +25,6 @@ describe("testIntructionsAdditionCarry", function () {
             operation[operation["ADC_" + r]](reg);
             expect(reg.A).toEqual(96);
             expect(reg[r]).toEqual(42);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
 
             // When A = 128, R = 200, and Carry = 0
             reg.A  = 128;
@@ -44,21 +34,11 @@ describe("testIntructionsAdditionCarry", function () {
             expect(reg.A).toEqual(72);
             expect(reg[r]).toEqual(200);
 
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(1);
-            expect(reg.PARITY).toEqual(1);
-
             // Tests double operation no fail
             reg.CARRY = 1;
             operation[operation["ADC_" + r]](reg);
             expect(reg.A).toEqual(17);
             expect(reg[r]).toEqual(200);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(1);
-            expect(reg.PARITY).toEqual(0);
         }
     });
 
@@ -72,21 +52,11 @@ describe("testIntructionsAdditionCarry", function () {
         operation[operation.ADC_A](reg);
         expect(reg.A).toEqual(0);
 
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
-
         // When A = 53 and carry = 1
         reg.A = 53;
         reg.CARRY = 1;
         operation[operation.ADC_A](reg);
         expect(reg.A).toEqual(107);
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(0);
 
         // When A = 127 and carry = 0
         reg.A = 127;
@@ -94,21 +64,11 @@ describe("testIntructionsAdditionCarry", function () {
         operation[operation.ADC_A](reg);
         expect(reg.A).toEqual(254);
 
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
-
         // When A = 128 and carry = 1
         reg.A = 128;
         reg.CARRY = 1;
         operation[operation.ADC_A](reg);
         expect(reg.A).toEqual(1);
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(1);
-        expect(reg.PARITY).toEqual(0);
 
         // When A = 250 and carry = 1
         reg.A = 250;
@@ -116,20 +76,10 @@ describe("testIntructionsAdditionCarry", function () {
         operation[operation.ADC_A](reg);
         expect(reg.A).toEqual(245);
 
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(1);
-        expect(reg.PARITY).toEqual(0);
-
         // Tests double operation no fail and carry = 0
         reg.CARRY = 1;
         operation[operation.ADC_A](reg);
         expect(reg.A).toEqual(235);
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(1);
-        expect(reg.PARITY).toEqual(0);
     });
 
     it("ADC M", function () {
@@ -140,11 +90,6 @@ describe("testIntructionsAdditionCarry", function () {
         reg.CARRY = 1;
         operation[operation["ADC_M"]](reg, 0, 0);
         expect(reg.A).toEqual(100);
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
     });
 
 });

--- a/test/hardware/instructions/Math.AdditionCarry.spec.js
+++ b/test/hardware/instructions/Math.AdditionCarry.spec.js
@@ -14,51 +14,51 @@ describe("testIntructionsAdditionCarry", function () {
 
             // When A = 0, R = 0, and Carry = 1
             reg.CARRY = 1;
-            operation[operation["ADC_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(1);      // 0 + 0 + 1 = 1
-            expect(reg[r]).toEqual(0);      // shouldn't be affected
+            operation[operation["ADC_" + r]](reg);
+            expect(reg.A).toEqual(1);
+            expect(reg[r]).toEqual(0);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(0); // 1 is odd
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(0);
 
             // When A = 53, R = 42, and Carry = 1
             reg.A  = 53;
             reg[r] = 42;
             reg.CARRY = 1;
-            operation[operation["ADC_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(96);     // 53 + 42 + 1 = 96
-            expect(reg[r]).toEqual(42);     // shouldn't be affected
+            operation[operation["ADC_" + r]](reg);
+            expect(reg.A).toEqual(96);
+            expect(reg[r]).toEqual(42);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // 96 is even
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
 
             // When A = 128, R = 200, and Carry = 0
             reg.A  = 128;
             reg[r] = 200;
             reg.CARRY = 0;
-            operation[operation["ADC_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(72);     // 128 + 200 + 0 = 328 -> 72
-            expect(reg[r]).toEqual(200);    // shouldn't be affected
+            operation[operation["ADC_" + r]](reg);
+            expect(reg.A).toEqual(72);
+            expect(reg[r]).toEqual(200);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(1);  // carry
-            expect(reg.PARITY).toEqual(1); // 72 is even
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(1);
+            expect(reg.PARITY).toEqual(1);
 
             // Tests double operation no fail
             reg.CARRY = 1;
-            operation[operation["ADC_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(17);     // 72 + 200 + 1 = 273 -> 17
-            expect(reg[r]).toEqual(200);    // shouldn't be affected
+            operation[operation["ADC_" + r]](reg);
+            expect(reg.A).toEqual(17);
+            expect(reg[r]).toEqual(200);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(1);  // carry
-            expect(reg.PARITY).toEqual(0); // 17 is odd
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(1);
+            expect(reg.PARITY).toEqual(0);
         }
     });
 
@@ -69,67 +69,67 @@ describe("testIntructionsAdditionCarry", function () {
 
         // When A = 0 and carry = 0
         reg.CARRY = 0;
-        operation[operation.ADC_A](reg);  // preform op
-        expect(reg.A).toEqual(0);      // 0 + 0 = 0
+        operation[operation.ADC_A](reg);
+        expect(reg.A).toEqual(0);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
 
         // When A = 53 and carry = 1
         reg.A = 53;
         reg.CARRY = 1;
-        operation[operation.ADC_A](reg);  // preform op
-        expect(reg.A).toEqual(107);    // 53 + 53 + 1 = 107
+        operation[operation.ADC_A](reg);
+        expect(reg.A).toEqual(107);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(0); // 107 is odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(0);
 
         // When A = 127 and carry = 0
         reg.A = 127;
         reg.CARRY = 0;
-        operation[operation.ADC_A](reg);  // preform op
-        expect(reg.A).toEqual(254);    // 127 + 127 + 0 = 254
+        operation[operation.ADC_A](reg);
+        expect(reg.A).toEqual(254);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 254 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
 
         // When A = 128 and carry = 1
         reg.A = 128;
         reg.CARRY = 1;
-        operation[operation.ADC_A](reg);  // preform op
-        expect(reg.A).toEqual(1);      // 128 + 128 + 1 = 257 -> 1
+        operation[operation.ADC_A](reg);
+        expect(reg.A).toEqual(1);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(1);  // carry
-        expect(reg.PARITY).toEqual(0); // 1 is odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(1);
+        expect(reg.PARITY).toEqual(0);
 
         // When A = 250 and carry = 1
         reg.A = 250;
         reg.CARRY = 1;
-        operation[operation.ADC_A](reg);  // preform op
-        expect(reg.A).toEqual(245);    // 250 + 250 + 1 = 501 -> 245
+        operation[operation.ADC_A](reg);
+        expect(reg.A).toEqual(245);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(1);  // carry
-        expect(reg.PARITY).toEqual(0); // 245 is odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(1);
+        expect(reg.PARITY).toEqual(0);
 
         // Tests double operation no fail and carry = 0
         reg.CARRY = 1;
-        operation[operation.ADC_A](reg);  // preform op
-        expect(reg.A).toEqual(235);    // 245 + 245 + 1 = 491 -> 235
+        operation[operation.ADC_A](reg);
+        expect(reg.A).toEqual(235);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // no zero
-        expect(reg.CARRY).toEqual(1);  // carry
-        expect(reg.PARITY).toEqual(0); // 233 is odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(1);
+        expect(reg.PARITY).toEqual(0);
     });
 
     it("ADC M", function () {
@@ -141,10 +141,10 @@ describe("testIntructionsAdditionCarry", function () {
         operation[operation["ADC_M"]](reg, 0, 0);
         expect(reg.A).toEqual(100);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 100 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
     });
 
 });

--- a/test/hardware/instructions/Math.And.spec.js
+++ b/test/hardware/instructions/Math.And.spec.js
@@ -19,11 +19,6 @@ describe("testInstructionsAnd", function() {
             operation[operation["ANA_" + r]](reg);
             expect(reg.A).toEqual(0);
             expect(reg[r]).toEqual(0);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(1);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
             
             // When A = 0b11111111 and R = 0b01010101
             reg.A = const1;
@@ -31,11 +26,6 @@ describe("testInstructionsAnd", function() {
             operation[operation["ANA_" + r]](reg);
             expect(reg.A).toEqual(const2);  // 0b11111111 & 0b01010101 = 0b01010101
             expect(reg[r]).toEqual(const2);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(0);
             
             // When A = 0b01010101 and R = 11001100
             reg.A = const2;
@@ -43,11 +33,6 @@ describe("testInstructionsAnd", function() {
             operation[operation["ANA_" + r]](reg);
             expect(reg.A).toEqual(const4);  // 0b01010101 & 0b00110011 = 0b01000100
             expect(reg[r]).toEqual(const3);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
             
             // When A = 0b01010101 and R = 00000000
             reg.A = const2;
@@ -55,11 +40,6 @@ describe("testInstructionsAnd", function() {
             operation[operation["ANA_" + r]](reg);
             expect(reg.A).toEqual(const0);  // 0b00000000 & 0b00110011 = 0b00000000
             expect(reg[r]).toEqual(const0);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(1);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
             
         }
     });
@@ -71,31 +51,16 @@ describe("testInstructionsAnd", function() {
         // When A = 0b0000-0000
         operation[operation.ANA_A](reg);
         expect(reg.A).toEqual(0);      // 0b0 & 0b0 = 0b0
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
             
         // When A = 0b11111111
         reg.A = const1;
         operation[operation.ANA_A](reg);
         expect(reg.A).toEqual(const1);  // 0b11111111 & 0b11111111 = 0b11111111
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(0);
             
         // When A = 0b01010101
         reg.A = const2;
         operation[operation.ANA_A](reg);
         expect(reg.A).toEqual(const2);  // 0b01010101 & 0b01010101 = 0b01010101
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(0);
             
     });
 
@@ -107,11 +72,6 @@ describe("testInstructionsAnd", function() {
         reg.A = const1;
         operation[operation["ANA_M"]](reg, 0, 0);
         expect(reg.A).toEqual(const2);  // 0b11111111 & 0b01010101 = 0b01010101
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(0);
     });
 
 });

--- a/test/hardware/instructions/Math.And.spec.js
+++ b/test/hardware/instructions/Math.And.spec.js
@@ -15,51 +15,51 @@ describe("testInstructionsAnd", function() {
             var reg = MolassesRegisters();
             var r = registers[i];
             
-            // When A = 0b0000-0000 and R = 0b0000-0000
-            operation[operation["ANA_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(0);      // 0b0 & 0b0 = 0b0
-            expect(reg[r]).toEqual(0);      // shouldn't be affected
+            // When A = 0b00000000 and R = 0b00000000
+            operation[operation["ANA_" + r]](reg);
+            expect(reg.A).toEqual(0);
+            expect(reg[r]).toEqual(0);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(1);   // zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // 0 is even
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(1);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
             
             // When A = 0b11111111 and R = 0b01010101
             reg.A = const1;
             reg[r] = const2;
-            operation[operation["ANA_" + r]](reg);  // preform op
+            operation[operation["ANA_" + r]](reg);
             expect(reg.A).toEqual(const2);  // 0b11111111 & 0b01010101 = 0b01010101
-            expect(reg[r]).toEqual(const2); // shouldn't be affected
+            expect(reg[r]).toEqual(const2);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(0); // odd
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(0);
             
             // When A = 0b01010101 and R = 11001100
             reg.A = const2;
             reg[r] = const3;
-            operation[operation["ANA_" + r]](reg);  // preform op
+            operation[operation["ANA_" + r]](reg);
             expect(reg.A).toEqual(const4);  // 0b01010101 & 0b00110011 = 0b01000100
-            expect(reg[r]).toEqual(const3); // shouldn't be affected
+            expect(reg[r]).toEqual(const3);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // even
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
             
             // When A = 0b01010101 and R = 00000000
             reg.A = const2;
             reg[r] = const0;
-            operation[operation["ANA_" + r]](reg);  // preform op
+            operation[operation["ANA_" + r]](reg);
             expect(reg.A).toEqual(const0);  // 0b00000000 & 0b00110011 = 0b00000000
-            expect(reg[r]).toEqual(const0); // shouldn't be affected
+            expect(reg[r]).toEqual(const0);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(1);   // zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // even
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(1);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
             
         }
     });
@@ -69,33 +69,33 @@ describe("testInstructionsAnd", function() {
         var reg = MolassesRegisters();
             
         // When A = 0b0000-0000
-        operation[operation.ANA_A](reg);  // preform op
+        operation[operation.ANA_A](reg);
         expect(reg.A).toEqual(0);      // 0b0 & 0b0 = 0b0
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
             
         // When A = 0b11111111
         reg.A = const1;
-        operation[operation.ANA_A](reg);  // preform op
+        operation[operation.ANA_A](reg);
         expect(reg.A).toEqual(const1);  // 0b11111111 & 0b11111111 = 0b11111111
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(0); // odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(0);
             
         // When A = 0b01010101
         reg.A = const2;
-        operation[operation.ANA_A](reg);  // preform op
+        operation[operation.ANA_A](reg);
         expect(reg.A).toEqual(const2);  // 0b01010101 & 0b01010101 = 0b01010101
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(0); // odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(0);
             
     });
 
@@ -108,10 +108,10 @@ describe("testInstructionsAnd", function() {
         operation[operation["ANA_M"]](reg, 0, 0);
         expect(reg.A).toEqual(const2);  // 0b11111111 & 0b01010101 = 0b01010101
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(0); // odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(0);
     });
 
 });

--- a/test/hardware/instructions/Math.Compare.spec.js
+++ b/test/hardware/instructions/Math.Compare.spec.js
@@ -11,44 +11,46 @@ describe("testIntructionsCMP", function() {
             reg = new MolassesRegisters();
 
             // When A = 0, R = 0
-            operation[operation["CMP_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(0);      // 0 - 0 = 0
-            expect(reg[r]).toEqual(0);     // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(1);   // zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // 0 is even
+            operation[operation["CMP_" + r]](reg);
+            expect(reg.A).toEqual(0);
+            expect(reg[r]).toEqual(0);
+
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(1);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
 
             // When A = 40, R = 33
             reg.A  = 40;
             reg[r] = 33;
-            operation[operation["CMP_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(40);      // 40 - 33 = 7
-            expect(reg[r]).toEqual(33);    // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(0); // 7 is odd
+            operation[operation["CMP_" + r]](reg);
+            expect(reg.A).toEqual(40);
+            expect(reg[r]).toEqual(33);
+
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(0);
 
             // When A = 20, R = 30
             reg.A  = 20;
             reg[r] = 30;
-            operation[operation["CMP_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(20);     // 20 - 30 = -10 -> 246
-            expect(reg[r]).toEqual(30);     // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(1);  // carry
-            expect(reg.PARITY).toEqual(1); // 246 is even
+            operation[operation["CMP_" + r]](reg);
+            expect(reg.A).toEqual(20);
+            expect(reg[r]).toEqual(30);
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(1);
+            expect(reg.PARITY).toEqual(1);
 
             // double operation without load, small output
-            operation[operation["CMP_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(20);     // 20 - 30 = -10 -> 246
-            expect(reg[r]).toEqual(30);     // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(1);  // carry
-            expect(reg.PARITY).toEqual(1); // 246 is even
+            operation[operation["CMP_" + r]](reg);
+            expect(reg.A).toEqual(20);
+            expect(reg[r]).toEqual(30);
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(1);
+            expect(reg.PARITY).toEqual(1);
             
         }
     });
@@ -58,29 +60,29 @@ describe("testIntructionsCMP", function() {
         reg = new MolassesRegisters(); 
         
         // When A = 0
-        operation[operation.CMP_A](reg);  // preform op
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        operation[operation.CMP_A](reg);
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
         
         // When A = 4
         reg.A = 4;
-        operation[operation.CMP_A](reg);  // preform op
-        expect(reg.A).toEqual(4);      // 4 - 4 = 0
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        operation[operation.CMP_A](reg);
+        expect(reg.A).toEqual(4);
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
         
         // When A = 77
         reg.A = 77;
-        operation[operation.CMP_A](reg);  // preform op
-        expect(reg.A).toEqual(77);      // 77 - 77 = 0
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        operation[operation.CMP_A](reg);
+        expect(reg.A).toEqual(77);
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
         
     });
 
@@ -91,11 +93,11 @@ describe("testIntructionsCMP", function() {
 
         reg.A = 40;
         operation[operation["CMP_M"]](reg, 0, 0);
-        expect(reg.A).toEqual(40);  // shouldn't have changed
+        expect(reg.A).toEqual(40);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(0); // 7 is odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(0);
     });
 });

--- a/test/hardware/instructions/Math.Or.spec.js
+++ b/test/hardware/instructions/Math.Or.spec.js
@@ -17,50 +17,50 @@ describe("testInstructionsORA", function() {
             var r = registers[i];
             
             // When A = 0b0000-0000 and R = 0b0000-0000
-            operation[operation["ORA_" + r]](reg);  // preform op
-            expect(reg.A).toEqual(0);      // 0b0 | 0b0 = 0b0
-            expect(reg[r]).toEqual(0);      // shouldn't be affected
+            operation[operation["ORA_" + r]](reg);
+            expect(reg.A).toEqual(0);
+            expect(reg[r]).toEqual(0);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(1);   // zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // 0 is even
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(1);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
             
             // When A = 0b11111111 and R = 0b01010101
             reg.A = const1;
             reg[r] = const2;
-            operation[operation["ORA_" + r]](reg);  // preform op
+            operation[operation["ORA_" + r]](reg);
             expect(reg.A).toEqual(const1);  // 0b11111111 | 0b01010101 = 0b11111111
-            expect(reg[r]).toEqual(const2); // shouldn't be affected
+            expect(reg[r]).toEqual(const2);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(0); // odd
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(0);
             
             // When A = 0b01010101 and R = 0b11001100
             reg.A = const2;
             reg[r] = const3;
-            operation[operation["ORA_" + r]](reg);  // preform op
+            operation[operation["ORA_" + r]](reg);
             expect(reg.A).toEqual(const5);  // 0b01010101 | 0b11001100 = 0b11011101
-            expect(reg[r]).toEqual(const3); // shouldn't be affected
+            expect(reg[r]).toEqual(const3);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(0); // odd
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(0);
             
             // When A = 0b01010101 and R = 0b00000000
             reg.A = const2;
             reg[r] = const0;
-            operation[operation["ORA_" + r]](reg);  // preform op
+            operation[operation["ORA_" + r]](reg);
             expect(reg.A).toEqual(const2);  // 0b00000000 | 0b00110011 = 0b00110011
-            expect(reg[r]).toEqual(const0); // shouldn't be affected
+            expect(reg[r]).toEqual(const0);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(0); // odd
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(0);
             
         }
     });
@@ -70,33 +70,33 @@ describe("testInstructionsORA", function() {
         var reg = MolassesRegisters();
 
         // When A = 0b00000000
-        operation[operation.ORA_A](reg);  // preform op
+        operation[operation.ORA_A](reg);
         expect(reg.A).toEqual(0);      // 0b0 & 0b0 = 0b0
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
 
         // When A = 0b11111111
         reg.A = const1;
-        operation[operation.ORA_A](reg);  // preform op
+        operation[operation.ORA_A](reg);
         expect(reg.A).toEqual(const1);  // 0b11111111 | 0b11111111 = 0b11111111
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(0); // odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(0);
 
         // When A = 0b01010101
         reg.A = const2;
-        operation[operation.ORA_A](reg);  // preform op
+        operation[operation.ORA_A](reg);
         expect(reg.A).toEqual(const2);  // 0b01010101 | 0b01010101 = 0b01010101
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(0); // odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(0);
 
     });
 
@@ -110,9 +110,9 @@ describe("testInstructionsORA", function() {
         operation[operation["ORA_M"]](reg, 0, 0);
         expect(reg.A).toEqual(const2);  // 0b00000000 | 0b00110011 = 0b00110011
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(0); // odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(0);
     });
 });

--- a/test/hardware/instructions/Math.Or.spec.js
+++ b/test/hardware/instructions/Math.Or.spec.js
@@ -20,11 +20,6 @@ describe("testInstructionsORA", function() {
             operation[operation["ORA_" + r]](reg);
             expect(reg.A).toEqual(0);
             expect(reg[r]).toEqual(0);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(1);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
             
             // When A = 0b11111111 and R = 0b01010101
             reg.A = const1;
@@ -32,11 +27,6 @@ describe("testInstructionsORA", function() {
             operation[operation["ORA_" + r]](reg);
             expect(reg.A).toEqual(const1);  // 0b11111111 | 0b01010101 = 0b11111111
             expect(reg[r]).toEqual(const2);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(0);
             
             // When A = 0b01010101 and R = 0b11001100
             reg.A = const2;
@@ -44,11 +34,6 @@ describe("testInstructionsORA", function() {
             operation[operation["ORA_" + r]](reg);
             expect(reg.A).toEqual(const5);  // 0b01010101 | 0b11001100 = 0b11011101
             expect(reg[r]).toEqual(const3);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(0);
             
             // When A = 0b01010101 and R = 0b00000000
             reg.A = const2;
@@ -56,11 +41,6 @@ describe("testInstructionsORA", function() {
             operation[operation["ORA_" + r]](reg);
             expect(reg.A).toEqual(const2);  // 0b00000000 | 0b00110011 = 0b00110011
             expect(reg[r]).toEqual(const0);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(0);
             
         }
     });
@@ -71,32 +51,17 @@ describe("testInstructionsORA", function() {
 
         // When A = 0b00000000
         operation[operation.ORA_A](reg);
-        expect(reg.A).toEqual(0);      // 0b0 & 0b0 = 0b0
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
+        expect(reg.A).toEqual(0); // 0b0 & 0b0 = 0b0
 
         // When A = 0b11111111
         reg.A = const1;
         operation[operation.ORA_A](reg);
         expect(reg.A).toEqual(const1);  // 0b11111111 | 0b11111111 = 0b11111111
 
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(0);
-
         // When A = 0b01010101
         reg.A = const2;
         operation[operation.ORA_A](reg);
         expect(reg.A).toEqual(const2);  // 0b01010101 | 0b01010101 = 0b01010101
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(0);
 
     });
 
@@ -109,10 +74,5 @@ describe("testInstructionsORA", function() {
         reg.A = const2;
         operation[operation["ORA_M"]](reg, 0, 0);
         expect(reg.A).toEqual(const2);  // 0b00000000 | 0b00110011 = 0b00110011
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(0);
     });
 });

--- a/test/hardware/instructions/Math.Subtraction.spec.js
+++ b/test/hardware/instructions/Math.Subtraction.spec.js
@@ -13,44 +13,47 @@ describe("testIntructionsSubtraction", function() {
             reg = new MolassesRegisters();
 
             // When A = 0, R = 0
-            operation[operation["SUB_" + r]](reg);  // preform op
+            operation[operation["SUB_" + r]](reg);
             expect(reg.A).toEqual(0);      // 0 - 0 = 0
-            expect(reg[r]).toEqual(0);     // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(1);   // zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // 0 is even
+            expect(reg[r]).toEqual(0);
+
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(1);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
 
             // When A = 40, R = 33
             reg.A  = 40;
             reg[r] = 33;
-            operation[operation["SUB_" + r]](reg);  // preform op
+            operation[operation["SUB_" + r]](reg);
             expect(reg.A).toEqual(7);      // 40 - 33 = 7
-            expect(reg[r]).toEqual(33);     // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(0); // 7 is odd
+            expect(reg[r]).toEqual(33);
+
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(0);
 
             // When A = 20, R = 30
             reg.A  = 20;
             reg[r] = 30;
-            operation[operation["SUB_" + r]](reg);  // preform op
+            operation[operation["SUB_" + r]](reg);
             expect(reg.A).toEqual(246);     // 20 - 30 = -10 -> 246
-            expect(reg[r]).toEqual(30);     // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(1);  // carry
-            expect(reg.PARITY).toEqual(1); // 246 is even
+            expect(reg[r]).toEqual(30);
+
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(1);
+            expect(reg.PARITY).toEqual(1);
 
             // double operation without load
-            operation[operation["SUB_" + r]](reg);  // preform op
+            operation[operation["SUB_" + r]](reg);
             expect(reg.A).toEqual(216);     // 246 - 30 = 216
-            expect(reg[r]).toEqual(30);     // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // cno arry
-            expect(reg.PARITY).toEqual(1); // 216 is even
+            expect(reg[r]).toEqual(30);
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
             
         }
     });
@@ -60,29 +63,29 @@ describe("testIntructionsSubtraction", function() {
         reg = new MolassesRegisters(); 
         
         // When A = 0
-        operation[operation.SUB_A](reg);  // preform op
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        operation[operation.SUB_A](reg);
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
         
         // When A = 4
         reg.A = 4;
-        operation[operation.SUB_A](reg);  // preform op
+        operation[operation.SUB_A](reg);
         expect(reg.A).toEqual(0);      // 4 - 4 = 0
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
         
         // When A = 77
         reg.A = 77;
-        operation[operation.SUB_A](reg);  // preform op
+        operation[operation.SUB_A](reg);
         expect(reg.A).toEqual(0);      // 77 - 77 = 0
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
         
     });
 
@@ -95,9 +98,9 @@ describe("testIntructionsSubtraction", function() {
         operation[operation["SUB_M"]](reg, 0, 0);
         expect(reg.A).toEqual(9);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(0); // 9 is odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(0);
     });
 });

--- a/test/hardware/instructions/Math.Subtraction.spec.js
+++ b/test/hardware/instructions/Math.Subtraction.spec.js
@@ -17,22 +17,12 @@ describe("testIntructionsSubtraction", function() {
             expect(reg.A).toEqual(0);      // 0 - 0 = 0
             expect(reg[r]).toEqual(0);
 
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(1);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
-
             // When A = 40, R = 33
             reg.A  = 40;
             reg[r] = 33;
             operation[operation["SUB_" + r]](reg);
             expect(reg.A).toEqual(7);      // 40 - 33 = 7
             expect(reg[r]).toEqual(33);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(0);
 
             // When A = 20, R = 30
             reg.A  = 20;
@@ -41,19 +31,10 @@ describe("testIntructionsSubtraction", function() {
             expect(reg.A).toEqual(246);     // 20 - 30 = -10 -> 246
             expect(reg[r]).toEqual(30);
 
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(1);
-            expect(reg.PARITY).toEqual(1);
-
             // double operation without load
             operation[operation["SUB_" + r]](reg);
             expect(reg.A).toEqual(216);     // 246 - 30 = 216
             expect(reg[r]).toEqual(30);
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
             
         }
     });
@@ -64,28 +45,16 @@ describe("testIntructionsSubtraction", function() {
         
         // When A = 0
         operation[operation.SUB_A](reg);
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
         
         // When A = 4
         reg.A = 4;
         operation[operation.SUB_A](reg);
         expect(reg.A).toEqual(0);      // 4 - 4 = 0
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
         
         // When A = 77
         reg.A = 77;
         operation[operation.SUB_A](reg);
         expect(reg.A).toEqual(0);      // 77 - 77 = 0
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
         
     });
 
@@ -97,10 +66,5 @@ describe("testIntructionsSubtraction", function() {
         reg.A = 30;
         operation[operation["SUB_M"]](reg, 0, 0);
         expect(reg.A).toEqual(9);
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(0);
     });
 });

--- a/test/hardware/instructions/Math.SubtractionCarry.spec.js
+++ b/test/hardware/instructions/Math.SubtractionCarry.spec.js
@@ -15,11 +15,6 @@ describe("testIntructionsSubtractionCarry", function() {
             expect(reg.A).toEqual(0);      // 0 - 0 - 0 = 0
             expect(reg[r]).toEqual(0);
 
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(1);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
-
             // When A = 40, R = 33 and carry = 1
             reg.A  = 40;
             reg[r] = 33;
@@ -27,11 +22,6 @@ describe("testIntructionsSubtractionCarry", function() {
             operation[operation["SBB_" + r]](reg);
             expect(reg.A).toEqual(6);      // 40 - 33 - 1 = 6
             expect(reg[r]).toEqual(33);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
 
             // When A = 20, R = 30 and carry = 0
             reg.A  = 20;
@@ -41,20 +31,11 @@ describe("testIntructionsSubtractionCarry", function() {
             expect(reg.A).toEqual(246);     // 20 - 30 - 0 = -10 -> 246
             expect(reg[r]).toEqual(30);
 
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(1);
-            expect(reg.PARITY).toEqual(1);
-
             // double operation without load and carry = 0
             reg.CARRY = 1;
             operation[operation["SBB_" + r]](reg);
             expect(reg.A).toEqual(215);     // 246 - 30 - 1 = 215
             expect(reg[r]).toEqual(30);
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(0);
             
         }
     });
@@ -66,32 +47,18 @@ describe("testIntructionsSubtractionCarry", function() {
         // When A = 0 and carry = 0
         reg.CARRY = 0;
         operation[operation.SBB_A](reg);
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
         
         // When A = 4 and carry = 1
         reg.A = 4;
         reg.CARRY = 1;
         operation[operation.SBB_A](reg);
         expect(reg.A).toEqual(255);    // 4 - 4 - 1 = -1 = 255
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(1);
-        expect(reg.PARITY).toEqual(0);
         
         // When A = 77 and carry = 1
         reg.A = 77;
         reg.CARRY = 1;
         operation[operation.SBB_A](reg);
         expect(reg.A).toEqual(255);    // 77 - 77 - 1 = -1 = 255
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(1);
-        expect(reg.PARITY).toEqual(0);
         
     });
 
@@ -104,10 +71,5 @@ describe("testIntructionsSubtractionCarry", function() {
         reg.CARRY = 1;
         operation[operation["SBB_M"]](reg, 0, 0);
         expect(reg.A).toEqual(8);
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
     });
 });

--- a/test/hardware/instructions/Math.SubtractionCarry.spec.js
+++ b/test/hardware/instructions/Math.SubtractionCarry.spec.js
@@ -11,47 +11,50 @@ describe("testIntructionsSubtractionCarry", function() {
 
             // When A = 0, R = 0 and carry = 0
             reg.CARRY = 0;
-            operation[operation["SBB_" + r]](reg);  // preform op
+            operation[operation["SBB_" + r]](reg);
             expect(reg.A).toEqual(0);      // 0 - 0 - 0 = 0
-            expect(reg[r]).toEqual(0);     // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(1);   // zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // 0 is even
+            expect(reg[r]).toEqual(0);
+
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(1);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
 
             // When A = 40, R = 33 and carry = 1
             reg.A  = 40;
             reg[r] = 33;
             reg.CARRY = 1;
-            operation[operation["SBB_" + r]](reg);  // preform op
+            operation[operation["SBB_" + r]](reg);
             expect(reg.A).toEqual(6);      // 40 - 33 - 1 = 6
-            expect(reg[r]).toEqual(33);     // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // 6 is even
+            expect(reg[r]).toEqual(33);
+
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
 
             // When A = 20, R = 30 and carry = 0
             reg.A  = 20;
             reg[r] = 30;
             reg.CARRY = 0;
-            operation[operation["SBB_" + r]](reg);  // preform op
+            operation[operation["SBB_" + r]](reg);
             expect(reg.A).toEqual(246);     // 20 - 30 - 0 = -10 -> 246
-            expect(reg[r]).toEqual(30);     // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(1);  // carry
-            expect(reg.PARITY).toEqual(1); // 246 is even
+            expect(reg[r]).toEqual(30);
+
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(1);
+            expect(reg.PARITY).toEqual(1);
 
             // double operation without load and carry = 0
             reg.CARRY = 1;
-            operation[operation["SBB_" + r]](reg);  // preform op
+            operation[operation["SBB_" + r]](reg);
             expect(reg.A).toEqual(215);     // 246 - 30 - 1 = 215
-            expect(reg[r]).toEqual(30);     // doesn't change
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(0); // 216 is odd
+            expect(reg[r]).toEqual(30);
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(0);
             
         }
     });
@@ -62,31 +65,33 @@ describe("testIntructionsSubtractionCarry", function() {
         
         // When A = 0 and carry = 0
         reg.CARRY = 0;
-        operation[operation.SBB_A](reg);// preform op
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        operation[operation.SBB_A](reg);
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
         
         // When A = 4 and carry = 1
         reg.A = 4;
         reg.CARRY = 1;
-        operation[operation.SBB_A](reg);// preform op
+        operation[operation.SBB_A](reg);
         expect(reg.A).toEqual(255);    // 4 - 4 - 1 = -1 = 255
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(1);  // carry
-        expect(reg.PARITY).toEqual(0); // 255 is odd
+
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(1);
+        expect(reg.PARITY).toEqual(0);
         
         // When A = 77 and carry = 1
         reg.A = 77;
         reg.CARRY = 1;
-        operation[operation.SBB_A](reg);// preform op
+        operation[operation.SBB_A](reg);
         expect(reg.A).toEqual(255);    // 77 - 77 - 1 = -1 = 255
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(1);  // carry
-        expect(reg.PARITY).toEqual(0); // 255 is odd
+
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(1);
+        expect(reg.PARITY).toEqual(0);
         
     });
 
@@ -100,9 +105,9 @@ describe("testIntructionsSubtractionCarry", function() {
         operation[operation["SBB_M"]](reg, 0, 0);
         expect(reg.A).toEqual(8);
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 8 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
     });
 });

--- a/test/hardware/instructions/Math.Xor.spec.js
+++ b/test/hardware/instructions/Math.Xor.spec.js
@@ -17,50 +17,50 @@ describe("testInstructionsXRA", function() {
             var r = registers[i];
             
             // When A = 0b0000-0000 and R = 0b0000-0000
-            operation[operation["XRA_" + r]](reg);  // preform op
+            operation[operation["XRA_" + r]](reg);
             expect(reg.A).toEqual(0);      // 0b0 ^ 0b0 = 0b0
-            expect(reg[r]).toEqual(0);      // shouldn't be affected
+            expect(reg[r]).toEqual(0);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(1);   // zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // 0 is even
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(1);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
             
             // When A = 0b11111111 and R = 0b01010101
             reg.A = const1;
             reg[r] = const2;
-            operation[operation["XRA_" + r]](reg);  // preform op
+            operation[operation["XRA_" + r]](reg);
             expect(reg.A).toEqual(parseInt("10101010", 2));  // 0b11111111 ^ 0b01010101 = 0b10101010
-            expect(reg[r]).toEqual(const2); // shouldn't be affected
+            expect(reg[r]).toEqual(const2);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(1); // 0 is even
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(1);
             
             // When A = 0b01010101 and R = 0b11001100
             reg.A = const2;
             reg[r] = const3;
-            operation[operation["XRA_" + r]](reg);  // preform op
+            operation[operation["XRA_" + r]](reg);
             expect(reg.A).toEqual(const5);  // 0b01010101 ^ 0b11001100 = 0b10011001
-            expect(reg[r]).toEqual(const3); // shouldn't be affected
+            expect(reg[r]).toEqual(const3);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(0); // odd
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(0);
             
             // When A = 0b01010101 and R = 0b00000000
             reg.A = const2;
             reg[r] = const0;
-            operation[operation["XRA_" + r]](reg);  // preform op
+            operation[operation["XRA_" + r]](reg);
             expect(reg.A).toEqual(const2);  // 0b00000000 ^ 0b00110011 = 0b00110011
-            expect(reg[r]).toEqual(const0); // shouldn't be affected
+            expect(reg[r]).toEqual(const0);
 
-            expect(reg.SIGN).toEqual(0);   // not negative
-            expect(reg.ZERO).toEqual(0);   // not zero
-            expect(reg.CARRY).toEqual(0);  // no carry
-            expect(reg.PARITY).toEqual(0); // odd
+            expect(reg.SIGN).toEqual(0);
+            expect(reg.ZERO).toEqual(0);
+            expect(reg.CARRY).toEqual(0);
+            expect(reg.PARITY).toEqual(0);
             
         }
     });
@@ -70,33 +70,33 @@ describe("testInstructionsXRA", function() {
         var reg = MolassesRegisters();
 
         // When A = 0b00000000
-        operation[operation.XRA_A](reg);  // preform op
+        operation[operation.XRA_A](reg);
         expect(reg.A).toEqual(0);      // 0b0 & 0b0 = 0b0
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
 
         // When A = 0b11111111
         reg.A = const1;
-        operation[operation.XRA_A](reg);  // preform op
+        operation[operation.XRA_A](reg);
         expect(reg.A).toEqual(const0);  // 0b11111111 ^ 0b11111111 = 0b00000000
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
 
         // When A = 0b01010101
         reg.A = const2;
-        operation[operation.XRA_A](reg);  // preform op
+        operation[operation.XRA_A](reg);
         expect(reg.A).toEqual(0);  // 0b01010101 ^ 0b01010101 = 0b00000000
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(1);   // zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(1); // 0 is even
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(1);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(1);
 
     });
 
@@ -110,9 +110,9 @@ describe("testInstructionsXRA", function() {
         operation[operation["XRA_M"]](reg, 0, 0);
         expect(reg.A).toEqual(const2);  // 0b00000000 ^ 0b00110011 = 0b00110011
 
-        expect(reg.SIGN).toEqual(0);   // not negative
-        expect(reg.ZERO).toEqual(0);   // not zero
-        expect(reg.CARRY).toEqual(0);  // no carry
-        expect(reg.PARITY).toEqual(0); // odd
+        expect(reg.SIGN).toEqual(0);
+        expect(reg.ZERO).toEqual(0);
+        expect(reg.CARRY).toEqual(0);
+        expect(reg.PARITY).toEqual(0);
     });
 });

--- a/test/hardware/instructions/Math.Xor.spec.js
+++ b/test/hardware/instructions/Math.Xor.spec.js
@@ -20,11 +20,6 @@ describe("testInstructionsXRA", function() {
             operation[operation["XRA_" + r]](reg);
             expect(reg.A).toEqual(0);      // 0b0 ^ 0b0 = 0b0
             expect(reg[r]).toEqual(0);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(1);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
             
             // When A = 0b11111111 and R = 0b01010101
             reg.A = const1;
@@ -32,11 +27,6 @@ describe("testInstructionsXRA", function() {
             operation[operation["XRA_" + r]](reg);
             expect(reg.A).toEqual(parseInt("10101010", 2));  // 0b11111111 ^ 0b01010101 = 0b10101010
             expect(reg[r]).toEqual(const2);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(1);
             
             // When A = 0b01010101 and R = 0b11001100
             reg.A = const2;
@@ -44,11 +34,6 @@ describe("testInstructionsXRA", function() {
             operation[operation["XRA_" + r]](reg);
             expect(reg.A).toEqual(const5);  // 0b01010101 ^ 0b11001100 = 0b10011001
             expect(reg[r]).toEqual(const3);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(0);
             
             // When A = 0b01010101 and R = 0b00000000
             reg.A = const2;
@@ -56,12 +41,6 @@ describe("testInstructionsXRA", function() {
             operation[operation["XRA_" + r]](reg);
             expect(reg.A).toEqual(const2);  // 0b00000000 ^ 0b00110011 = 0b00110011
             expect(reg[r]).toEqual(const0);
-
-            expect(reg.SIGN).toEqual(0);
-            expect(reg.ZERO).toEqual(0);
-            expect(reg.CARRY).toEqual(0);
-            expect(reg.PARITY).toEqual(0);
-            
         }
     });
     
@@ -73,30 +52,15 @@ describe("testInstructionsXRA", function() {
         operation[operation.XRA_A](reg);
         expect(reg.A).toEqual(0);      // 0b0 & 0b0 = 0b0
 
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
-
         // When A = 0b11111111
         reg.A = const1;
         operation[operation.XRA_A](reg);
         expect(reg.A).toEqual(const0);  // 0b11111111 ^ 0b11111111 = 0b00000000
 
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
-
         // When A = 0b01010101
         reg.A = const2;
         operation[operation.XRA_A](reg);
         expect(reg.A).toEqual(0);  // 0b01010101 ^ 0b01010101 = 0b00000000
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(1);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(1);
 
     });
 
@@ -109,10 +73,5 @@ describe("testInstructionsXRA", function() {
         reg.A = const2;
         operation[operation["XRA_M"]](reg, 0, 0);
         expect(reg.A).toEqual(const2);  // 0b00000000 ^ 0b00110011 = 0b00110011
-
-        expect(reg.SIGN).toEqual(0);
-        expect(reg.ZERO).toEqual(0);
-        expect(reg.CARRY).toEqual(0);
-        expect(reg.PARITY).toEqual(0);
     });
 });


### PR DESCRIPTION
The Jasmine unit tests are too bulky and have too many comments. A lot of the comments have been copy pasted and are not updated as the code has changed. 

- [x] Remove extra `flag` register asserts
- [x] Remove comments that don't add any useful information

This is a pretty quick change